### PR TITLE
changed contract.new() to deployer.deploy() in migrations

### DIFF
--- a/contracts/3-DevZenDao/DevZenDaoAuto.sol
+++ b/contracts/3-DevZenDao/DevZenDaoAuto.sol
@@ -2,13 +2,13 @@ pragma solidity ^0.4.24;
 // to enable Params passing to constructor and method
 pragma experimental ABIEncoderV2;
 
-import "@thetta/core/contracts/utils/GenericCaller.sol";
+import "@thetta/core/contracts/DaoBaseAuto.sol";
 
 import "./DevZenDao.sol";
 import "./DevZenDaoCore.sol";
 import "./DevZenDaoWithUnpackers.sol";
 
-contract DevZenDaoAuto is GenericCaller{
+contract DevZenDaoAuto is DaoBaseAuto{
 	event UpdateDaoParamsAuto();
 	event WithdrawEtherAuto();
 	event SelectNextHostAuto();
@@ -17,7 +17,7 @@ contract DevZenDaoAuto is GenericCaller{
 	event MoveToNextEpisodeAuto();
 
 	DevZenDaoWithUnpackers devZenDao;
-	constructor(IDaoBase _daoBase, DevZenDaoWithUnpackers _devZenDao) public GenericCaller(_daoBase){
+	constructor(IDaoBase _daoBase, DevZenDaoWithUnpackers _devZenDao) public DaoBaseAuto(_daoBase){
 		devZenDao = _devZenDao;
 	}
 

--- a/contracts/3-DevZenDao/DevZenDaoAutoTestable.sol
+++ b/contracts/3-DevZenDao/DevZenDaoAutoTestable.sol
@@ -2,15 +2,15 @@ pragma solidity ^0.4.24;
 // to enable Params passing to constructor and method
 pragma experimental ABIEncoderV2;
 
-import "@thetta/core/contracts/utils/GenericCaller.sol";
+import "@thetta/core/contracts/DaoBaseAuto.sol";
 
 import "./DevZenDao.sol";
 import "./DevZenDaoCore.sol";
 import "./DevZenDaoWithUnpackersTestable.sol";
 
-contract DevZenDaoAutoTestable is GenericCaller{
+contract DevZenDaoAutoTestable is DaoBaseAuto{
 	DevZenDaoWithUnpackersTestable devZenDao;
-	constructor(IDaoBase _daoBase, DevZenDaoWithUnpackersTestable _devZenDao) public GenericCaller(_daoBase){
+	constructor(IDaoBase _daoBase, DevZenDaoWithUnpackersTestable _devZenDao) public DaoBaseAuto(_daoBase){
 		devZenDao = _devZenDao;
 	}
 

--- a/migrations/3_deploy_devZenDao.js
+++ b/migrations/3_deploy_devZenDao.js
@@ -15,12 +15,12 @@ let emp2 = '0x38ed1a11e4f2fd85995a058e1f65d41a483a662a';
 let emp3 = '0x92bc71cd9a9a6ad3a1dcacc2b8c9eab13f4d547e';
 
 module.exports = function(deployer, network, accounts) {
-	return deployer.then(async () => {	
-		let devZenToken = await StdDaoToken.new("DevZenToken", "DZT", 18, true, true, 100000000000000000000);
-		let repToken = await StdDaoToken.new("DevZenRepToken", "DZTREP", 18, true, true, 100000000000000000000);
-		let store = await DaoStorage.new([devZenToken.address, repToken.address]);
-		let daoBase = await DaoBase.new(store.address);
-		let devZenDao = await DevZenDaoWithUnpackers.new(daoBase.address, [devZenToken.address, repToken.address]);
+	return deployer.then(async () => {
+		let devZenToken = await deployer.deploy(StdDaoToken, "DevZenToken", "DZT", 18, true, true, 100000000000000000000);
+		let repToken = await deployer.deploy(StdDaoToken, "DevZenRepToken", "DZTREP", 18, true, true, 100000000000000000000);
+		let store = await deployer.deploy(DaoStorage, [devZenToken.address, repToken.address]);
+		let daoBase = await deployer.deploy(DaoBase, store.address);
+		let devZenDao = await deployer.deploy(DevZenDaoWithUnpackers, daoBase.address, [devZenToken.address, repToken.address]);
 
 		await store.allowActionByAddress(await daoBase.MANAGE_GROUPS(),accounts[0]);
 		await store.allowActionByAddress(await daoBase.ISSUE_TOKENS(),devZenDao.address);
@@ -61,7 +61,7 @@ module.exports = function(deployer, network, accounts) {
 		await daoBase.allowActionByVoting(await devZenDao.DEV_ZEN_EMERGENCY_CHANGE_GUEST(), repToken.address);
 		await daoBase.allowActionByVoting(await devZenDao.DEV_ZEN_MOVE_TO_NEXT_EPISODE(), repToken.address);
 	
-		let devZenDaoAuto = await DevZenDaoAuto.new(daoBase.address, devZenDao.address);
+		let devZenDaoAuto = await deployer.deploy(DevZenDaoAuto, daoBase.address, devZenDao.address);
 
 		await daoBase.allowActionByAddress(await daoBase.ADD_NEW_PROPOSAL(), devZenDaoAuto.address);
 		await daoBase.allowActionByAddress(await daoBase.MANAGE_GROUPS(), devZenDaoAuto.address);

--- a/migrations/4_deploy_HierarchyDao.js
+++ b/migrations/4_deploy_HierarchyDao.js
@@ -15,10 +15,10 @@ let emp3 = '0x92bc71cd9a9a6ad3a1dcacc2b8c9eab13f4d547e';
 
 module.exports = function(deployer, network, accounts) {
 	return deployer.then(async () => {	
-		let token = await StdDaoToken.new("StdToken", "STD", 18, true, true, 100000000000000000000);
-		let store = await DaoStorage.new([token.address]);
-		let daoBase = await DaoBase.new(store.address);
-		let hierarcyDao = await HierarchyDao.new(daoBase.address);
+		let token = await deployer.deploy(StdDaoToken, "StdToken", "STD", 18, true, true, 100000000000000000000);
+		let store = await deployer.deploy(DaoStorage, [token.address]);
+		let daoBase = await deployer.deploy(DaoBase, store.address);
+		let hierarchyDao = await deployer.deploy(HierarchyDao, daoBase.address);
 
 		await store.allowActionByAddress(await daoBase.MANAGE_GROUPS(), accounts[0]);
 		await store.transferOwnership(daoBase.address);
@@ -39,7 +39,7 @@ module.exports = function(deployer, network, accounts) {
 		await daoBase.addGroupMember("Employees", emp2);
 		await daoBase.addGroupMember("Employees", emp3);
 
-		let hierarchyDaoAuto = await DaoBaseAuto.new(daoBase.address);
+		let hierarchyDaoAuto = await deployer.deploy(DaoBaseAuto, daoBase.address);
 
 		// set voring params 1 person 1 vote
 		let VOTING_TYPE_1P1V = 1;

--- a/migrations/5_deploy_BodDao.js
+++ b/migrations/5_deploy_BodDao.js
@@ -15,10 +15,10 @@ let emp3 = '0x92bc71cd9a9a6ad3a1dcacc2b8c9eab13f4d547e';
 
 module.exports = function(deployer, network, accounts) {
 	return deployer.then(async () => {	
-		let token = await StdDaoToken.new("StdToken", "STD", 18, true, true, 100000000000000000000);
-		let store = await DaoStorage.new([token.address]);
-		let daoBase = await DaoBase.new(store.address);
-		let bodDao = await BodDao.new(daoBase.address);
+		let token = await deployer.deploy(StdDaoToken, "StdToken", "STD", 18, true, true, 100000000000000000000);
+		let store = await deployer.deploy(DaoStorage, [token.address]);
+		let daoBase = await deployer.deploy(DaoBase, store.address);
+		let bodDao = await deployer.deploy(BodDao, daoBase.address);
 
 		await store.allowActionByAddress(await daoBase.MANAGE_GROUPS(), accounts[0]);
 
@@ -40,7 +40,7 @@ module.exports = function(deployer, network, accounts) {
 		await daoBase.addGroupMember("Employees", emp2);
 		await daoBase.addGroupMember("Employees", emp3);
 	
-		let bodDaoAuto = await DaoBaseAuto.new(daoBase.address);
+		let bodDaoAuto = await deployer.deploy(DaoBaseAuto, daoBase.address);
 
 		let VOTING_TYPE_1P1V = 1;
 		await bodDaoAuto.setVotingParams(await daoBase.MANAGE_GROUPS(), VOTING_TYPE_1P1V, uintToBytes32(0), fromUtf8("BoD"), uintToBytes32(49), uintToBytes32(49), 0);


### PR DESCRIPTION
There is a difference in console output between contract.new() and deployer.deploy(). With plain contract.new() it's tricky to get deployed contract address.

// console output with deployer.deploy()
Deploying DevZenDaoAuto...
... 0x9078235b3d2319df149e136f1281b4253ad471930c13104bd9c7346a0f0b727b
DevZenDaoAuto: 0x3d8f2deaefc9b85da74a8a9e85826fc4cbc090cb

// console output with DevZenDaoAuto.new()
... 0x9078235b3d2319df149e136f1281b4253ad471930c13104bd9c7346a0f0b727b